### PR TITLE
Hide from nav menus UI

### DIFF
--- a/inc/class-documents-post-type.php
+++ b/inc/class-documents-post-type.php
@@ -55,13 +55,14 @@ class Documents_Post_Type {
 		);
 
 		$documents_args = array(
-			'labels'          => $documents_labels,
-			'public'          => true,
-			'capability_type' => 'post',
-			'hierarchical'    => false,
-			'show_in_menu'    => 'upload.php',
-			'menu_icon'       => 'dashicons-media-document',
-			'supports'        => array(
+			'labels'            => $documents_labels,
+			'public'            => true,
+			'capability_type'   => 'post',
+			'hierarchical'      => false,
+			'show_in_menu'      => 'upload.php',
+			'show_in_nav_menus' => false,
+			'menu_icon'         => 'dashicons-media-document',
+			'supports'          => array(
 				'title',
 				'editor',
 				'author',
@@ -70,10 +71,10 @@ class Documents_Post_Type {
 				'custom-fields',
 				'thumbnail',
 			),
-			'rewrite'         => array( 'slug' => admin\get_plugin_info( 'slug' ) ),
-			'show_in_rest'    => true,
-			'template'        => array( array( 'hrswp/document-select' ) ),
-			'template_lock'   => 'all',
+			'rewrite'           => array( 'slug' => admin\get_plugin_info( 'slug' ) ),
+			'show_in_rest'      => true,
+			'template'          => array( array( 'hrswp/document-select' ) ),
+			'template_lock'     => 'all',
 		);
 
 		register_post_type( admin\get_plugin_info( 'post_type' ), $documents_args );


### PR DESCRIPTION
## Description

It isn't a good idea to include PDFs and other documents directly in nav menus, so hide this CPT from the nav menu.

## How has this been tested?

Works as expected in local environment.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run test` -->
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- [x] I've included developer documentation if appropriate.
