### PR TITLE
Add taxonomies to documents CPT

### DIFF
--- a/inc/class-documents-post-type.php
+++ b/inc/class-documents-post-type.php
@@ -34,6 +34,9 @@ class Documents_Post_Type {
 	 * @return void
 	 */
 	public function action_register_post_types() {
+		// Make sure the HRS Unit taxonomy exists before using it.
+		$hrs_unit_tax = taxonomy_exists( 'hrs_unit' ) ? 'hrs_unit' : '';
+
 		$documents_labels = array(
 			'name'                  => esc_html_x( 'Document Manager', 'post type general name', 'hrswp-documents' ),
 			'singular_name'         => esc_html_x( 'Document', 'post type singular name', 'hrswp-documents' ),
@@ -70,6 +73,7 @@ class Documents_Post_Type {
 				'custom-fields',
 				'thumbnail',
 			),
+			'taxonomies'      => array( 'category', 'post_tag', $hrs_unit_tax ),
 			'rewrite'         => array( 'slug' => admin\get_plugin_info( 'slug' ) ),
 			'show_in_rest'    => true,
 			'template'        => array( array( 'hrswp/document-select' ) ),


### PR DESCRIPTION
## Description

Add taxonomies to the Documents CPT.

## How has this been tested?

Works as expected in local environment.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run test` -->
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- [x] I've included developer documentation if appropriate.
