### PR TITLE
Remove revision tracking since it only catches title

### DIFF
--- a/inc/class-documents-post-type.php
+++ b/inc/class-documents-post-type.php
@@ -66,7 +66,6 @@ class Documents_Post_Type {
 				'editor',
 				'author',
 				'excerpt',
-				'revisions',
 				'custom-fields',
 				'thumbnail',
 			),


### PR DESCRIPTION
## Description

Remove revision tracking since it only catches changes to the title.

## How has this been tested?

Works as expected in local environment.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run test` -->
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- [x] I've included developer documentation if appropriate.
