### PR TITLE
Fix/db cache

### DIFF
--- a/lib/data.php
+++ b/lib/data.php
@@ -42,29 +42,35 @@ function update_plugin_info() {
 add_action( 'admin_init', __NAMESPACE__ . '\update_plugin_info' );
 
 /**
-* Moves all HRSWP Documents custom post types to the trash.
-*
-* Uses a direct MySQL command with the $wpdb object in order to prevent
-* memory-based timeouts when trying to trash many posts.
-*
-* @since 1.1.0
-*
-* @return int|false The number of rows affected by the query or false if a MySQL error is encountered.
-*/
+ * Moves all HRSWP Documents custom post types to the trash.
+ *
+ * Uses a direct MySQL command with the $wpdb object in order to prevent
+ * memory-based timeouts when trying to trash many posts.
+ *
+ * @since 1.1.0
+ *
+ * @return int|false The number of rows affected by the query or false if a MySQL error is encountered.
+ */
 function trash_documents() {
 	global $wpdb;
 
-	return $wpdb->query(
-		$wpdb->prepare(
-			"
-			UPDATE `$wpdb->posts`
-			SET `post_status` = %s
-			WHERE `post_type` = %s
-			",
-			'trash',
-			admin\get_plugin_info( 'post_type' )
-		)
-	);
+	$result = wp_cache_get( 'trash_posts', admin\get_plugin_info( 'post_type' ) );
+	if ( false === $result ) {
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"
+				UPDATE `$wpdb->posts`
+				SET `post_status` = %s
+				WHERE `post_type` = %s
+				",
+				'trash',
+				admin\get_plugin_info( 'post_type' )
+			)
+		);
+		wp_cache_set( 'trash_posts', $result, admin\get_plugin_info( 'post_type' ) );
+	}
+
+	return $result;
 }
 
 /**

--- a/lib/data.php
+++ b/lib/data.php
@@ -56,6 +56,7 @@ function trash_documents() {
 
 	$result = wp_cache_get( 'trash_posts', admin\get_plugin_info( 'post_type' ) );
 	if ( false === $result ) {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 		$result = $wpdb->query(
 			$wpdb->prepare(
 				"


### PR DESCRIPTION
## Description

Fix phpcs issue regarding direct database calls and lack of `wp_cache_*` use. Ignore the warning about direct database calls because the alternative is much slower and causes timeout issues with large numbers of posts. Add `wp_cache_get` and `wp_cache_set` on the trash posts method, though it probably has no effect since the uninstall function only fires once by design.

## How has this been tested?

Works as expected in local environment.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run test` -->
- [x] My code follows the accessibility standards.
- [x] My code has proper inline documentation.
- [x] I've included developer documentation if appropriate.
